### PR TITLE
Adding an analyzer script to get the basic status of the Yamaha AV receiver

### DIFF
--- a/adapter/yamaha/lib/yamaha_service.js
+++ b/adapter/yamaha/lib/yamaha_service.js
@@ -177,6 +177,22 @@ exports.now_playing = (function(callback){
     });
 });
 
+/**
+ * requests the  basic status of the receiver.
+ * @type {Function}
+ * @param callback
+ */
+exports.basic_status = (function(callback){
+    var request_data = build_request_data(HTTP_METHODS.GET, "<Basic_Status>GetParam</Basic_Status>");
+    var http_request = yapi.http_request(request_data);
+
+    connect_to_yamaha(function(data){
+        callback(data.toString());
+    });
+
+    write_to_yamaha(http_request);
+});
+
 /* ----------------------PRIVATE FUNCTIONS---------------------------- */
 
 connect_to_yamaha = (function(data_callback){

--- a/adapter/yamaha/yamaha_basic_status.js
+++ b/adapter/yamaha/yamaha_basic_status.js
@@ -1,0 +1,36 @@
+/**
+ * CCU.IO adapter for Yamaha AV receiver
+ *
+ * Copyright 2013-2014 Thorsten Kamann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var yservice = require("./lib/yamaha_service");
+var ylogger = require("./lib/yamaha_logger");
+var settings = require(__dirname+'/../../settings.js');
+var ysettings = settings.adapters.yamaha.settings;
+
+/**
+ * Requests the basic status of the Yamaha AV receiver
+ */
+exports.get_basic_status = function(){
+    ylogger.log_level(ylogger.LEVEL.info);
+    yservice.inject_logger(ylogger);
+    yservice.setup(ysettings.host, ysettings.port, ysettings.zone);
+    yservice.basic_status(function(data){
+       ylogger.info(data);
+    });
+}
+
+this.get_basic_status();


### PR DESCRIPTION
v1.1.1

For error handling this small script requests a basic status of a Yamaha AV receiver. So ist easier to check why a features doesn't work as it should.
