### PR TITLE
Adding getState, setState, setObject, delObject as part of the ScriptEngine. These are only delegates without copy/paste of the logic.

### DIFF
--- a/script-engine.js
+++ b/script-engine.js
@@ -674,11 +674,28 @@ var scriptEngine = {
             }
         });
     },
+
     stop: function () {
         scriptEngine.logger.info("script-engine terminating");
         setTimeout(function () {
             process.exit();
         }, 250);
+    },
+
+    getState: function(id, dpType){
+        return getState(id, dpType);
+    },
+
+    setState: function(id, val, callback){
+        setState(id, val, callback) ;
+    },
+
+    setObject: function(id, obj, callback){
+        setObject(id, obj, callback);
+    },
+
+    delObject: function(id){
+        delObject(id);
     }
 }
 


### PR DESCRIPTION
Adding getState, setState, setObject, delObject as part of the ScriptEngine.
These are only delegates without copy/paste of the logic.

Now you can do this:

scriptEngine.setState(xxx); in scripts that not directly called by the scriptengine, eg. helper scripts.
