### PR TITLE
Fix: script-engine/getTimestamp() returned value

### DIFF
--- a/script-engine.js
+++ b/script-engine.js
@@ -814,8 +814,13 @@ function getState(id, dpType) {
 }
 
 
-function getTimestamp(id) {
-    return datapoints[id][0];
+function getTimestamp(id, dpType) {
+    var dp = datapoints[findDatapoint(id, dpType)];
+    if (dp) {
+        return dp[1];
+    } else {
+        return null;
+    }
 }
 
 function executeProgram(id, callback) {


### PR DESCRIPTION
There was an error in getTimestamp(), which returned dp[0] instead of dp[1].
I also adopted the implementation of getState() to find the datapoint.