### PR TITLE
Fix: Firefox did not re-enable Check Update button

### DIFF
--- a/www/ccu.io/js/ccu.io.js
+++ b/www/ccu.io/js/ccu.io.js
@@ -443,6 +443,7 @@ $(document).ready(function () {
             var url = "http://ccu.io/version.php";
             socket.emit("getUrl", url, function(res) {
                 $("#update_self_check").hide();
+                $("#update_self_check").attr("disabled", false);
                 $(".ccu-io-availversion").html(res);
                 if (compareVersion(ccuIoSettings.version, res)) {
                     $("#update_self").show().click(function () {


### PR DESCRIPTION
Steps to reproduce: open CCU.IO interface in Firefox, check for updates and verify available version.
Click "reload" to open the page again, see the check button again, but still disabled. You would have to reenter the URL or close and reopen the tab/window to check for updates again.
This fixes this by unsetting the disabled attribute after hiding the button.